### PR TITLE
chore: specify Yarn version and update README

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/README.md
+++ b/README.md
@@ -1,51 +1,75 @@
-# Pregen Wallet Example
+# Capsule Pregenerated Wallet Integration Example
+
+This repository provides an example of integrating Capsule's Pregenerated Wallets (Pregen Wallets) into your application. Pregenerated Wallets allow partners to create wallets on behalf of users using their email addresses. This example demonstrates how to set up the development environment, create pregen wallets, manage user shares, and handle signing of messages and transactions. It also covers the process for users to claim their pregenerated wallets through the Capsule signup flow or manually.
 
 ## Getting Started
 
-Install the dependencies:
+1. Ensure you have Yarn installed globally. If not, you can install it by running:
 
-```bash
-yarn
-```
+   ```bash
+   npm install -g yarn
+   ```
 
-Run the development server:
-```bash
-yarn dev
-```
+   or
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+   ```bash
+   corepack enable
+   ```
+
+2. Install the dependencies:
+
+   ```bash
+   yarn
+   ```
+
+3. Add a `.env` or `.env.local` file with the following content:
+
+   ```
+   NEXT_PUBLIC_CAPSULE_API_KEY=<your_beta_access_key>
+   ```
+
+4. Run the development server:
+
+   ```bash
+   yarn dev
+   ```
+
+5. Open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
+
+**Note:** This repository specifies Yarn Classic (v1.22.19) in the `package.json` to ensure compatibility. The version file `1.22.19.cjs` is included in the `.yarn/releases` directory, ensuring that the correct Yarn version is used when you install dependencies.
 
 ## How Pregen Works
 
-Pregenerated Wallets or pregen, are wallets that are created by a partner on behalf of a user. They can be created with an email which then can be used to claim them.
+Pregenerated Wallets, or "pregen" wallets, are wallets created by a partner on behalf of a user. They can be created using the user's email, which can then be used to claim the wallets.
 
 ### General Integration
 
-- create a pregen wallet on behalf of a user using an email the user controls
+- Create a pregen wallet on behalf of a user using their email:
 
-```typescript
- await capsule.createWalletPreGen(userEmail);
-```
+  ```typescript
+  await capsule.createWalletPreGen(userEmail);
+  ```
 
-- Capsule will create a wallet using your `partnerId` and associate to `userEmail`
-- You can also set and get the user share
+- Capsule will create a wallet using your `partnerId` and associate it with `userEmail`.
 
-```typescript
- await capsule.setUserShare(base64Wallet)
- await capsule.getUserShare()
-```
+- You can also set and get the user's share:
 
-- You can also sign messages and transactions as usual, Capsule will know if it is for a pregen wallet or a regular user wallet:
+  ```typescript
+  await capsule.setUserShare(base64Wallet);
+  await capsule.getUserShare();
+  ```
 
-```typescript
-await capsule.signMessage(walletId, messageBase64)
-await capsule.signTransaction(walletId, rlpEncodedTxBase64, chainId)
-```
+- You can sign messages and transactions as usual. Capsule will determine if the wallet is a pregen wallet or a regular user wallet:
 
-- When users with a pregenerated wallet go through the capsule signup flow using the associated email, their wallet is automatically claimed instead of creating a new wallet.
+  ```typescript
+  await capsule.signMessage(walletId, messageBase64);
+  await capsule.signTransaction(walletId, rlpEncodedTxBase64, chainId);
+  ```
 
-Alternatively, pregen wallets can be "manually" claimed using:
+- When users with a pregenerated wallet go through the Capsule signup flow using the associated email, their wallet is automatically claimed instead of creating a new wallet.
 
-```typescript
-await capsule.claimPregenWallet(claimPregenEmail)
-```
+- Alternatively, pregen wallets can be manually claimed using:
+
+  ```typescript
+  await capsule.claimPregenWallet(claimPregenEmail);
+  ```

--- a/package.json
+++ b/package.json
@@ -11,19 +11,20 @@
   "dependencies": {
     "@usecapsule/ethers-v6-integration": "1.3.0",
     "@usecapsule/web-sdk": "1.4.0",
+    "next": "14.1.1",
     "react": "^18",
-    "react-dom": "^18",
-    "next": "14.1.1"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "eslint": "^8",
+    "eslint-config-next": "14.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "eslint": "^8",
-    "eslint-config-next": "14.1.1"
-  }
+    "typescript": "^5"
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Ensures usage of compatible Yarn version (v1.22.19) is used by specifying it in the package.json and including the version file in the .yarn/releases directory. Updates the README with instructions for setting up the development environment, including Yarn installation and configuration.